### PR TITLE
Feature/actualizar horarios prescripcion mobile

### DIFF
--- a/src/mobile-functions/prescriptions/dto/update-prescription-schedule.dto.ts
+++ b/src/mobile-functions/prescriptions/dto/update-prescription-schedule.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsArray,
+  IsDate,
+  IsEnum,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export enum ScheduleUpdateScope {
+  FUTURE_ONLY = 'FUTURE_ONLY',
+  PERMANENT = 'PERMANENT',
+}
+
+export class UpdatePrescriptionScheduleDto {
+  @ApiProperty({
+    description:
+      'Array of time slots for medication (e.g., ["08:00", "14:00", "20:00"])',
+    example: ['08:00', '14:00', '20:00'],
+    type: [String],
+    required: false,
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  time_of_day_slots?: string[];
+
+  @ApiProperty({
+    description:
+      'New first dose taken timestamp (if updating the schedule permanently)',
+    example: '2025-06-10T08:00:00.000Z',
+    type: Date,
+    required: false,
+  })
+  @IsDate()
+  @Type(() => Date)
+  @IsOptional()
+  @ValidateIf((o) => o.scope === ScheduleUpdateScope.PERMANENT)
+  first_dose_taken_at?: Date;
+
+  @ApiProperty({
+    description:
+      'Scope of the schedule update - affects only future doses or permanently changes the schedule',
+    enum: ScheduleUpdateScope,
+    example: ScheduleUpdateScope.FUTURE_ONLY,
+  })
+  @IsEnum(ScheduleUpdateScope)
+  scope: ScheduleUpdateScope;
+}

--- a/src/mobile-functions/prescriptions/prescriptions.controller.ts
+++ b/src/mobile-functions/prescriptions/prescriptions.controller.ts
@@ -23,6 +23,7 @@ import {
   AdjustDoseTimeDto,
 } from './dto/medication-dose-log.dto';
 import { CancelTrackingDto } from './dto/cancel-tracking.dto';
+import { MedicationAdherenceStatsDto } from '../../medical-scheduling/modules/prescription/dto/medication-tracking-response.dto';
 import { RequirePermission } from '../../auth/decorators/require-permission.decorator';
 import { Permission } from '../../auth/permissions/permission.enum';
 import { PermissionGuard } from '../../auth/guards/permission.guard';
@@ -321,6 +322,7 @@ export class PrescriptionsController {
   @ApiResponse({
     status: 200,
     description: 'Returns medication adherence statistics',
+    type: MedicationAdherenceStatsDto,
   })
   @RequirePermission(Permission.VIEW_OWN_PRESCRIPTIONS)
   async getMedicationAdherence(

--- a/src/mobile-functions/prescriptions/prescriptions.controller.ts
+++ b/src/mobile-functions/prescriptions/prescriptions.controller.ts
@@ -23,6 +23,7 @@ import {
   AdjustDoseTimeDto,
 } from './dto/medication-dose-log.dto';
 import { CancelTrackingDto } from './dto/cancel-tracking.dto';
+import { UpdatePrescriptionScheduleDto } from './dto/update-prescription-schedule.dto';
 import { MedicationAdherenceStatsDto } from '../../medical-scheduling/modules/prescription/dto/medication-tracking-response.dto';
 import { RequirePermission } from '../../auth/decorators/require-permission.decorator';
 import { Permission } from '../../auth/permissions/permission.enum';
@@ -291,6 +292,42 @@ export class PrescriptionsController {
       userTenants,
     );
   }
+
+  @Patch(':prescription_id/schedule')
+  @ApiOperation({ summary: 'Update prescription schedule' })
+  @ApiParam({
+    name: 'prescription_id',
+    description: 'Prescription ID to update schedule for',
+  })
+  @ApiBody({ type: UpdatePrescriptionScheduleDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Prescription schedule updated successfully',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request - Invalid input or tracking not active',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Prescription not found',
+  })
+  @RequirePermission(Permission.VIEW_OWN_PRESCRIPTIONS)
+  async updateSchedule(
+    @Request() req,
+    @Param('prescription_id') prescriptionId: string,
+    @Body() updateDto: UpdatePrescriptionScheduleDto,
+  ) {
+    const patientId = req.user.id;
+    const userTenants = req.userTenants || [];
+    return this.prescriptionsService.updateSchedule(
+      prescriptionId,
+      patientId,
+      updateDto,
+      userTenants,
+    );
+  }
+
   @Get('medication-skip-reasons')
   @ApiOperation({ summary: 'Get medication skip reasons catalog' })
   @ApiResponse({

--- a/src/mobile-functions/prescriptions/prescriptions.controller.ts
+++ b/src/mobile-functions/prescriptions/prescriptions.controller.ts
@@ -300,4 +300,45 @@ export class PrescriptionsController {
   async getMedicationSkipReasons() {
     return this.prescriptionsService.getMedicationSkipReasons();
   }
+
+  @Get('medication-adherence')
+  @ApiOperation({ summary: 'Get medication adherence statistics' })
+  @ApiQuery({
+    name: 'period_start',
+    required: false,
+    description: 'Start date for adherence calculation (ISO 8601 format)',
+  })
+  @ApiQuery({
+    name: 'period_end',
+    required: false,
+    description: 'End date for adherence calculation (ISO 8601 format)',
+  })
+  @ApiQuery({
+    name: 'prescription_id',
+    required: false,
+    description: 'Specific prescription ID to calculate adherence for',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns medication adherence statistics',
+  })
+  @RequirePermission(Permission.VIEW_OWN_PRESCRIPTIONS)
+  async getMedicationAdherence(
+    @Request() req,
+    @Query('period_start') periodStart?: string,
+    @Query('period_end') periodEnd?: string,
+    @Query('prescription_id') prescriptionId?: string,
+  ) {
+    const patientId = req.user.id;
+
+    const periodStartDate = periodStart ? new Date(periodStart) : undefined;
+    const periodEndDate = periodEnd ? new Date(periodEnd) : undefined;
+
+    return this.prescriptionsService.calculateMedicationAdherence(
+      patientId,
+      prescriptionId,
+      periodStartDate,
+      periodEndDate,
+    );
+  }
 }


### PR DESCRIPTION
Implementación de endpoint para actualizar horarios de prescripciones móviles

Este PR agrega la funcionalidad para que los pacientes puedan modificar los horarios de toma de sus medicamentos a través de la aplicación móvil.

Características principales:
• Nuevo endpoint PATCH /mobile/prescriptions/:prescription_id/schedule
• Permite actualizar time_of_day_slots y first_dose_taken_at
• Soporte para dos tipos de cambios:
  - FUTURE_ONLY: afecta solo las tomas futuras del día actual
  - PERMANENT: recalcula permanentemente todo el esquema de medicación
• Validaciones robustas de formato y seguridad
• Mantiene compatibilidad con el sistema multitenant existente

Archivos modificados:
• Nuevo DTO: update-prescription-schedule.dto.ts
• Controller: prescriptions.controller.ts (nuevo endpoint)
• Service: prescriptions.service.ts (nueva lógica de negocio)

Esta funcionalidad mejora la flexibilidad del sistema de seguimiento de medicamentos permitiendo a los pacientes ajustar sus horarios según sus necesidades.