### PR TITLE
Feature/scheduler para marcar citas missed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,7 +1785,6 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/bullmq/-/bullmq-11.0.2.tgz",
       "integrity": "sha512-Lq6lGpKkETsm0RDcUktlzsthFoE3A5QTMp2FwPi1eztKqKD6/90KS1TcnC9CJFzjpUaYnQzIMrlNs55e+/wsHA==",
-      "license": "MIT",
       "dependencies": {
         "@nestjs/bull-shared": "^11.0.2",
         "tslib": "2.8.1"
@@ -4692,7 +4691,6 @@
       "version": "5.53.2",
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.53.2.tgz",
       "integrity": "sha512-xHgxrP/yNJHD7VCw1h+eRBh+2TCPBCM39uC9gCyksYc6ufcJP+HTZ/A2lzB2x7qMFWrvsX7tM40AT2BmdkYL/Q==",
-      "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.9.0",
         "ioredis": "^5.4.1",
@@ -9836,7 +9834,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
       "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
-      "license": "MIT",
       "dependencies": {
         "clone": "2.x"
       },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -769,6 +769,7 @@ enum status_type {
   atendida
   cancelada
   pendiente
+  no_asistida
 }
 
 enum tenant_type {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -44,6 +44,7 @@ import { PhysicianScheduleModule } from './medical-scheduling/modules/physician-
 import { TenantAccessGuard } from './auth/guards/tenant-access.guard';
 import { SettingsModule } from './medical-scheduling/modules/settings/settings.module';
 import { MedicationSchedulerModule } from './services/medication-scheduler/medication-scheduler.module';
+import { AppointmentSchedulerModule } from './services/appointment-scheduler/appointment-scheduler.module';
 
 config({ path: '.env' });
 
@@ -104,6 +105,7 @@ config({ path: '.env' });
     PhysicianScheduleModule,
     SettingsModule,
     MedicationSchedulerModule,
+    AppointmentSchedulerModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/docs/appointment-scheduler.md
+++ b/src/docs/appointment-scheduler.md
@@ -8,7 +8,7 @@ El `AppointmentSchedulerService` es un servicio automatizado que se ejecuta como
 
 ### 1. Procesamiento Automático
 
-- **Cron Job**: Se ejecuta cada hora (`@Cron(CronExpression.EVERY_HOUR)`)
+- **Cron Job**: Se ejecuta diariamente a medianoche (`@Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)`)
 - **Función**: Revisa todas las citas con estado "pendiente" cuya fecha/hora de fin ya ha pasado
 - **Acción**: Las marca automáticamente como "no_asistida"
 
@@ -44,7 +44,7 @@ El `AppointmentSchedulerService` es un servicio automatizado que se ejecuta como
 ### Frecuencia del Cron Job
 
 ```typescript
-@Cron(CronExpression.EVERY_HOUR)
+@Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
 async processExpiredAppointments(): Promise<void>
 ```
 
@@ -52,8 +52,8 @@ Para cambiar la frecuencia, modifica la expresión cron:
 
 - `CronExpression.EVERY_5_MINUTES` - Cada 5 minutos
 - `CronExpression.EVERY_30_MINUTES` - Cada 30 minutos
-- `CronExpression.EVERY_HOUR` - Cada hora (actual)
-- `CronExpression.EVERY_6_HOURS` - Cada 6 horas
+- `CronExpression.EVERY_HOUR` - Cada hora
+- `CronExpression.EVERY_DAY_AT_MIDNIGHT` - Diariamente a medianoche (actual)
 
 ## Logging
 

--- a/src/docs/appointment-scheduler.md
+++ b/src/docs/appointment-scheduler.md
@@ -1,0 +1,125 @@
+# Appointment Scheduler Service
+
+## Descripción
+
+El `AppointmentSchedulerService` es un servicio automatizado que se ejecuta como un cron job para marcar automáticamente las citas médicas pendientes como "no_asistida" cuando han pasado su hora de finalización.
+
+## Funcionalidades
+
+### 1. Procesamiento Automático
+
+- **Cron Job**: Se ejecuta cada hora (`@Cron(CronExpression.EVERY_HOUR)`)
+- **Función**: Revisa todas las citas con estado "pendiente" cuya fecha/hora de fin ya ha pasado
+- **Acción**: Las marca automáticamente como "no_asistida"
+
+### 2. Procesamiento Manual
+
+- **Endpoint**: `POST /appointment-scheduler/process-expired`
+- **Uso**: Permite ejecutar manualmente el proceso de marcado de citas expiradas
+- **Respuesta**: Retorna el número de citas procesadas y la lista de citas afectadas
+
+### 3. Estadísticas
+
+- **Endpoint**: `GET /appointment-scheduler/statistics`
+- **Parámetros opcionales**:
+  - `startDate`: Fecha de inicio para filtrar
+  - `endDate`: Fecha de fin para filtrar
+  - `tenantId`: ID del tenant para filtrar
+- **Respuesta**: Conteo de citas por estado (pendiente, atendida, cancelada, no_asistida)
+
+## Archivos Implementados
+
+### Core Service
+
+- `src/services/appointment-scheduler/appointment-scheduler.service.ts`
+- `src/services/appointment-scheduler/appointment-scheduler.module.ts`
+- `src/services/appointment-scheduler/appointment-scheduler.controller.ts`
+
+### Integración
+
+- Módulo agregado al `app.module.ts`
+
+## Configuración
+
+### Frecuencia del Cron Job
+
+```typescript
+@Cron(CronExpression.EVERY_HOUR)
+async processExpiredAppointments(): Promise<void>
+```
+
+Para cambiar la frecuencia, modifica la expresión cron:
+
+- `CronExpression.EVERY_5_MINUTES` - Cada 5 minutos
+- `CronExpression.EVERY_30_MINUTES` - Cada 30 minutos
+- `CronExpression.EVERY_HOUR` - Cada hora (actual)
+- `CronExpression.EVERY_6_HOURS` - Cada 6 horas
+
+## Logging
+
+El servicio registra toda su actividad:
+
+- Inicio de procesamiento
+- Número de citas encontradas
+- Número de citas procesadas
+- Detalles de cada cita marcada como no_asistida (en modo debug)
+- Errores si ocurren
+
+## Seguridad
+
+- El controlador está protegido con `TenantAccessGuard`
+- Requiere autenticación Bearer token
+- Solo usuarios autenticados pueden ejecutar procesamiento manual o ver estadísticas
+
+## Testing
+
+### Test Manual via API
+
+```bash
+# Procesar citas expiradas manualmente
+curl -X POST http://localhost:3000/appointment-scheduler/process-expired \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Obtener estadísticas
+curl -X GET http://localhost:3000/appointment-scheduler/statistics \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Estadísticas con filtros
+curl -X GET "http://localhost:3000/appointment-scheduler/statistics?startDate=2025-01-01&endDate=2025-12-31&tenantId=TENANT_ID" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+## Base de Datos
+
+### Estados de Cita
+
+El enum `status_type` incluye:
+
+- `pendiente` - Cita programada, no realizada aún
+- `atendida` - Cita completada exitosamente
+- `cancelada` - Cita cancelada
+- `no_asistida` - Cita perdida/no asistida (nuevo estado)
+
+### Consulta de Citas Expiradas
+
+```sql
+SELECT * FROM appointment
+WHERE status = 'pendiente'
+  AND "end" < NOW()
+  AND deleted = false;
+```
+
+## Monitoring
+
+Para monitorear el servicio en producción:
+
+1. Revisar logs del contenedor/aplicación
+2. Usar el endpoint de estadísticas para verificar que se están procesando citas
+3. Configurar alertas si el número de citas "no_asistida" aumenta significativamente
+
+## Próximos Pasos (Fase 3)
+
+1. **Testing unitario** del servicio
+2. **Configuración de monitoreo** y alertas
+3. **Métricas** de rendimiento
+4. **Notificaciones** opcionales cuando se marcan citas como no_asistida

--- a/src/docs/medical-events.md
+++ b/src/docs/medical-events.md
@@ -64,7 +64,8 @@ Crea un nuevo evento médico. Este endpoint se utiliza generalmente al iniciar u
   "main_diagnostic_cie": "A00.1",
   "evolution": "Evolución inicial del paciente.",
   "procedure": "Procedimiento inicial realizado.",
-  "treatment": "Tratamiento inicial indicado."
+  "treatment": "Tratamiento inicial indicado.",
+  "specialty_id": 1
 }
 ```
 
@@ -132,6 +133,7 @@ Obtiene una lista de eventos médicos, con opciones de filtrado y paginación.
 
 - `patient_id` (string, opcional): Filtrar por ID del paciente (UUID).
 - `physician_id` (string, opcional): Filtrar por ID del médico (UUID).
+- `specialty_id` (number, opcional): Filtrar por ID de la especialidad médica.
 - `page` (number, opcional): Número de página para paginación.
 - `pageSize` (number, opcional): Número de eventos por página.
 - `orderBy` (string, opcional): Campo por el cual ordenar (ej. `created_at`).
@@ -141,6 +143,15 @@ Obtiene una lista de eventos médicos, con opciones de filtrado y paginación.
 
 ```http
 GET /medical-events?patient_id=b5191b80-2a8d-4eb2-9958-9273a0708025&pageSize=10&page=1
+Host: localhost:3000
+Authorization: Bearer <JWT_TOKEN>
+X-Tenant-ID: <TENANT_UUID>
+```
+
+**Ejemplo de Petición con Filtro por Especialidad:**
+
+```http
+GET /medical-events?physician_id=dbacf6c6-6918-41e0-8923-4de0ce59eb84&specialty_id=1&pageSize=10&page=1
 Host: localhost:3000
 Authorization: Bearer <JWT_TOKEN>
 X-Tenant-ID: <TENANT_UUID>
@@ -310,6 +321,7 @@ Usado para crear un evento médico.
 - `evolution?: string` (Opcional) - Evolución del paciente.
 - `procedure?: string` (Opcional) - Procedimientos realizados.
 - `treatment?: string` (Opcional) - Tratamiento indicado.
+- `specialty_id?: number` (Opcional) - ID de la especialidad médica para validación.
 
 ### `AttendMedicalEventDto`
 

--- a/src/medical-scheduling/appointments/appointments.controller.ts
+++ b/src/medical-scheduling/appointments/appointments.controller.ts
@@ -43,6 +43,7 @@ import {
 @UseGuards(TenantAccessGuard, PermissionGuard)
 export class AppointmentsController {
   constructor(private readonly appointmentsService: AppointmentsService) {}
+
   @Post()
   @ApiOperation({
     summary: 'Crear cita',
@@ -82,6 +83,7 @@ export class AppointmentsController {
       tenant.id,
     );
   }
+
   @Get('user')
   @ApiOperation({
     summary: 'Obtener citas del usuario',
@@ -105,6 +107,12 @@ export class AppointmentsController {
     required: false,
     type: Number,
   })
+  @ApiQuery({
+    name: 'specialty_id',
+    description: 'ID de la especialidad médica para filtrar citas',
+    required: false,
+    type: Number,
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Citas del usuario devueltas exitosamente',
@@ -121,10 +129,12 @@ export class AppointmentsController {
   async getAppointmentsByUser(
     @GetUser() user,
     @GetTenant() tenant,
-    @Query() params: { status?: status_type } & PaginationParams,
+    @Query()
+    params: { status?: status_type; specialty_id?: number } & PaginationParams,
   ) {
     return this.appointmentsService.getAppointmentsByUser(user.id, params);
   }
+
   @Patch(':id/status')
   @ApiOperation({
     summary: 'Actualizar estado de cita',
@@ -186,6 +196,7 @@ export class AppointmentsController {
       tenant,
     );
   }
+
   @Get('physician-calendar')
   @ApiOperation({
     summary: 'Obtener calendario del médico',
@@ -247,8 +258,10 @@ export class AppointmentsController {
       tenant.id,
       params.month,
       params.year,
+      params.specialty_id,
     );
   }
+
   @Get('physician/:physicianId/calendar')
   @ApiOperation({
     summary: 'Get specific physician calendar',
@@ -316,8 +329,10 @@ export class AppointmentsController {
       tenant.id,
       params.month,
       params.year,
+      params.specialty_id,
     );
   }
+
   @Get('statistics')
   @ApiOperation({
     summary: 'Get appointment statistics',

--- a/src/medical-scheduling/appointments/appointments.service.ts
+++ b/src/medical-scheduling/appointments/appointments.service.ts
@@ -171,6 +171,48 @@ export class AppointmentsService {
     }
   }
 
+  // Method to validate if physician has the required specialty
+  private async validatePhysicianSpecialty(
+    physicianId: string,
+    specialtyId: number,
+  ): Promise<{ isValid: boolean; reason?: string }> {
+    try {
+      // Check if the physician has the specified specialty
+      const physicianSpecialty =
+        await this.prisma.physician_speciality.findFirst({
+          where: {
+            physician: {
+              user_id: physicianId,
+              deleted: false,
+            },
+            speciality_id: specialtyId,
+          },
+          include: {
+            speciality: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        });
+
+      if (!physicianSpecialty) {
+        return {
+          isValid: false,
+          reason: 'El médico seleccionado no tiene la especialidad requerida',
+        };
+      }
+
+      return { isValid: true };
+    } catch (error) {
+      console.error('Error validating physician specialty:', error);
+      return {
+        isValid: false,
+        reason: 'Error al validar la especialidad del médico',
+      };
+    }
+  }
+
   async createAppointment(
     data: CreateAppointmentDto,
     tenant: string,
@@ -210,11 +252,25 @@ export class AppointmentsService {
         endDate,
         tenant,
       );
-
       if (!scheduleCheck.isAvailable) {
         throw new BadRequestException(
           scheduleCheck.reason || 'El horario no está disponible',
         );
+      }
+
+      // Validar especialidad del médico si se proporciona
+      if (data.specialty_id) {
+        const specialtyCheck = await this.validatePhysicianSpecialty(
+          data.physician_id,
+          data.specialty_id,
+        );
+
+        if (!specialtyCheck.isValid) {
+          throw new BadRequestException(
+            specialtyCheck.reason ||
+              'El médico no tiene la especialidad requerida',
+          );
+        }
       }
 
       // Verificar conflicto de horarios con otras citas

--- a/src/medical-scheduling/appointments/dto/create-appointment.dto.ts
+++ b/src/medical-scheduling/appointments/dto/create-appointment.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEnum,
   IsOptional,
   IsNotEmpty,
+  IsNumber,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { status_type } from '@prisma/client';
@@ -92,4 +93,17 @@ export class CreateAppointmentDto {
   @IsOptional()
   @IsUUID('4', { message: 'El ID del inquilino debe ser un UUID válido' })
   tenant_id?: string;
+
+  @ApiProperty({
+    description: 'ID de la especialidad médica requerida para la cita',
+    example: 1,
+    type: Number,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber(
+    {},
+    { message: 'El ID de la especialidad debe ser un número válido' },
+  )
+  specialty_id?: number;
 }

--- a/src/medical-scheduling/appointments/dto/create-appointment.dto.ts
+++ b/src/medical-scheduling/appointments/dto/create-appointment.dto.ts
@@ -63,14 +63,13 @@ export class CreateAppointmentDto {
   @IsUUID()
   @IsNotEmpty()
   physician_id: string;
-
   @ApiProperty({
     description: 'Estado de la cita',
-    enum: ['atendida', 'cancelada', 'pendiente'],
+    enum: ['atendida', 'cancelada', 'pendiente', 'no_asistida'],
     default: 'pendiente',
     required: false,
   })
-  @IsEnum(['atendida', 'cancelada', 'pendiente'])
+  @IsEnum(['atendida', 'cancelada', 'pendiente', 'no_asistida'])
   @IsOptional()
   status?: status_type;
 

--- a/src/medical-scheduling/appointments/dto/get-appointments-calendar.dto.ts
+++ b/src/medical-scheduling/appointments/dto/get-appointments-calendar.dto.ts
@@ -62,4 +62,15 @@ export class GetAppointmentsCalendarDto {
   @IsOptional()
   @Transform(({ value }) => parseInt(value, 10))
   year?: number;
+
+  @ApiProperty({
+    description: 'ID de la especialidad médica para filtrar citas',
+    example: 1,
+    type: Number,
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  specialty_id?: number;
 }

--- a/src/medical-scheduling/medical-events/dto/create-medical-event.dto.ts
+++ b/src/medical-scheduling/medical-events/dto/create-medical-event.dto.ts
@@ -4,8 +4,10 @@ import {
   IsNotEmpty,
   IsOptional,
   IsNumber,
+  IsInt,
+  Min,
 } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateMedicalEventDto {
   @ApiProperty({
@@ -67,7 +69,6 @@ export class CreateMedicalEventDto {
   @IsString()
   @IsOptional()
   procedure?: string;
-
   @ApiProperty({
     description: 'Optional description of the treatment provided',
     example: 'Prescribed Amoxicillin 500mg every 8 hours for 7 days.',
@@ -76,4 +77,14 @@ export class CreateMedicalEventDto {
   @IsString()
   @IsOptional()
   treatment?: string;
+
+  @ApiPropertyOptional({
+    description: 'ID of the medical specialty for this event (optional)',
+    example: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsInt({ message: 'specialty_id debe ser un número entero' })
+  @Min(1, { message: 'specialty_id debe ser mayor a 0' })
+  specialty_id?: number;
 }

--- a/src/medical-scheduling/medical-events/medical-events.controller.ts
+++ b/src/medical-scheduling/medical-events/medical-events.controller.ts
@@ -56,6 +56,12 @@ export class MedicalEventsController {
     description: 'Filter by physician ID',
   })
   @ApiQuery({
+    name: 'specialty_id',
+    required: false,
+    type: Number,
+    description: 'Filter by medical specialty ID',
+  })
+  @ApiQuery({
     name: 'page',
     required: false,
     type: Number,
@@ -87,6 +93,7 @@ export class MedicalEventsController {
   async getMedicalEvents(
     @Query('patient_id') patient_id?: string,
     @Query('physician_id') physician_id?: string,
+    @Query('specialty_id') specialty_id?: number,
     @Query('page') page?: number,
     @Query('pageSize') pageSize?: number,
     @Query('orderBy') orderBy?: string,
@@ -95,6 +102,7 @@ export class MedicalEventsController {
     const filters = {
       patient_id,
       physician_id,
+      specialty_id,
       page,
       pageSize,
       orderBy,

--- a/src/mobile-functions/appointments/appointments.controller.ts
+++ b/src/mobile-functions/appointments/appointments.controller.ts
@@ -54,6 +54,14 @@ export class MobileAppointmentsController {
       'If true, returns only the next pending appointment. If false or not specified, returns all appointments grouped by status.',
     example: true,
   })
+  @ApiQuery({
+    name: 'specialty_id',
+    required: false,
+    type: Number,
+    description:
+      'Filter appointments by physician specialty ID. Only shows appointments with physicians that have this specialty.',
+    example: 1,
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Appointments retrieved successfully',

--- a/src/mobile-functions/appointments/appointments.controller.ts
+++ b/src/mobile-functions/appointments/appointments.controller.ts
@@ -169,13 +169,13 @@ export class MobileAppointmentsController {
   @ApiResponse({
     status: HttpStatus.UNAUTHORIZED,
     description: 'Unauthorized - Invalid or missing JWT token',
-  })
-  @ApiResponse({
+  })  @ApiResponse({
     status: HttpStatus.FORBIDDEN,
     description: 'Forbidden - Insufficient permissions to view appointments',
   })
   async getAppointments(
     @Query('home') home?: string,
+    @Query('specialty_id') specialtyId?: string,
     @Request() req?: any,
   ): Promise<NextAppointmentResponseDto | AllAppointmentsResponseDto> {
     try {
@@ -193,6 +193,9 @@ export class MobileAppointmentsController {
 
       const patientId = req.user.id;
       const userTenants = req.userTenants; // Tenants del JWT
+      
+      // Convertir specialty_id de string a number si se proporciona
+      const specialty_id = specialtyId ? parseInt(specialtyId, 10) : undefined;
 
       // Determinar si se solicita solo la próxima cita o todas
       const isHomeRequest = home === 'true';
@@ -202,12 +205,14 @@ export class MobileAppointmentsController {
         return await this.mobileAppointmentsService.getNextAppointment(
           patientId,
           userTenants,
+          specialty_id,
         );
       } else {
         // Obtener todas las citas agrupadas
         return await this.mobileAppointmentsService.getAllAppointments(
           patientId,
           userTenants,
+          specialty_id,
         );
       }
     } catch (error) {

--- a/src/mobile-functions/appointments/appointments.controller.ts
+++ b/src/mobile-functions/appointments/appointments.controller.ts
@@ -169,7 +169,8 @@ export class MobileAppointmentsController {
   @ApiResponse({
     status: HttpStatus.UNAUTHORIZED,
     description: 'Unauthorized - Invalid or missing JWT token',
-  })  @ApiResponse({
+  })
+  @ApiResponse({
     status: HttpStatus.FORBIDDEN,
     description: 'Forbidden - Insufficient permissions to view appointments',
   })
@@ -193,7 +194,7 @@ export class MobileAppointmentsController {
 
       const patientId = req.user.id;
       const userTenants = req.userTenants; // Tenants del JWT
-      
+
       // Convertir specialty_id de string a number si se proporciona
       const specialty_id = specialtyId ? parseInt(specialtyId, 10) : undefined;
 

--- a/src/mobile-functions/appointments/appointments.service.ts
+++ b/src/mobile-functions/appointments/appointments.service.ts
@@ -37,7 +37,8 @@ export class MobileAppointmentsService {
         deleted: false,
       },
       select: { tenant_id: true },
-    });    return patientTenants.map((pt) => pt.tenant_id);
+    });
+    return patientTenants.map((pt) => pt.tenant_id);
   }
 
   /**
@@ -99,7 +100,7 @@ export class MobileAppointmentsService {
       });
 
       if (!nextAppointment) {
-        const message = specialtyId 
+        const message = specialtyId
           ? 'No se encontraron citas pendientes para la especialidad especificada'
           : 'No se encontraron citas pendientes';
         return {
@@ -148,7 +149,8 @@ export class MobileAppointmentsService {
       };
     } catch (error) {
       throw new BadRequestException(
-        `Error al obtener el próximo turno: ${error.message}`,      );
+        `Error al obtener el próximo turno: ${error.message}`,
+      );
     }
   }
 
@@ -278,7 +280,8 @@ export class MobileAppointmentsService {
       // Ordenar: pendientes por fecha ascendente, pasadas por fecha descendente
       pending.sort(
         (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
-      );      past.sort(
+      );
+      past.sort(
         (a, b) => new Date(b.start).getTime() - new Date(a.start).getTime(),
       );
 
@@ -289,7 +292,7 @@ export class MobileAppointmentsService {
         past_count: past.length,
       };
 
-      const message = specialtyId 
+      const message = specialtyId
         ? 'Citas filtradas por especialidad obtenidas exitosamente'
         : 'Citas obtenidas exitosamente';
 

--- a/src/services/appointment-scheduler/appointment-scheduler.controller.ts
+++ b/src/services/appointment-scheduler/appointment-scheduler.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Post, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { AppointmentSchedulerService } from './appointment-scheduler.service';
+import { TenantAccessGuard } from 'src/auth/guards/tenant-access.guard';
+
+@ApiTags('appointment-scheduler')
+@Controller('appointment-scheduler')
+@UseGuards(TenantAccessGuard)
+@ApiBearerAuth()
+export class AppointmentSchedulerController {
+  constructor(
+    private readonly appointmentSchedulerService: AppointmentSchedulerService,
+  ) {}
+
+  @Post('process-expired')
+  @ApiOperation({
+    summary: 'Procesar manualmente citas expiradas',
+    description:
+      'Ejecuta manualmente el proceso de marcado de citas pendientes como no_asistida',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Proceso ejecutado exitosamente',
+    schema: {
+      type: 'object',
+      properties: {
+        processedCount: { type: 'number' },
+        expiredAppointments: { type: 'array' },
+      },
+    },
+  })
+  async processExpiredAppointments() {
+    return await this.appointmentSchedulerService.manualProcessExpiredAppointments();
+  }
+
+  @Get('statistics')
+  @ApiOperation({
+    summary: 'Obtener estadísticas de citas por estado',
+    description:
+      'Devuelve el conteo de citas por estado en un rango de fechas opcional',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Estadísticas obtenidas exitosamente',
+    schema: {
+      type: 'object',
+      properties: {
+        total: { type: 'number' },
+        pendiente: { type: 'number' },
+        atendida: { type: 'number' },
+        cancelada: { type: 'number' },
+        no_asistida: { type: 'number' },
+      },
+    },
+  })
+  async getStatistics(
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('tenantId') tenantId?: string,
+  ) {
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+
+    return await this.appointmentSchedulerService.getAppointmentStatusStatistics(
+      start,
+      end,
+      tenantId,
+    );
+  }
+}

--- a/src/services/appointment-scheduler/appointment-scheduler.module.ts
+++ b/src/services/appointment-scheduler/appointment-scheduler.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppointmentSchedulerService } from './appointment-scheduler.service';
 import { AppointmentSchedulerController } from './appointment-scheduler.controller';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { GuardAuthModule } from 'src/auth/guard-auth.module';
 
 @Module({
+  imports: [GuardAuthModule],
   controllers: [AppointmentSchedulerController],
   providers: [AppointmentSchedulerService, PrismaService],
   exports: [AppointmentSchedulerService],

--- a/src/services/appointment-scheduler/appointment-scheduler.module.ts
+++ b/src/services/appointment-scheduler/appointment-scheduler.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AppointmentSchedulerService } from './appointment-scheduler.service';
+import { AppointmentSchedulerController } from './appointment-scheduler.controller';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Module({
+  controllers: [AppointmentSchedulerController],
+  providers: [AppointmentSchedulerService, PrismaService],
+  exports: [AppointmentSchedulerService],
+})
+export class AppointmentSchedulerModule {}

--- a/src/services/appointment-scheduler/appointment-scheduler.service.ts
+++ b/src/services/appointment-scheduler/appointment-scheduler.service.ts
@@ -8,12 +8,11 @@ export class AppointmentSchedulerService {
   private readonly logger = new Logger(AppointmentSchedulerService.name);
 
   constructor(private readonly prisma: PrismaService) {}
-
   /**
-   * Cron job que se ejecuta cada hora para revisar citas pendientes que ya han finalizado
+   * Cron job que se ejecuta diariamente para revisar citas pendientes que ya han finalizado
    * y marcarlas como "no_asistida"
    */
-  @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async processExpiredAppointments(): Promise<void> {
     this.logger.log(
       'Iniciando procesamiento de citas expiradas para marcar como no_asistida...',

--- a/src/services/appointment-scheduler/appointment-scheduler.service.ts
+++ b/src/services/appointment-scheduler/appointment-scheduler.service.ts
@@ -1,0 +1,205 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { status_type } from '@prisma/client';
+
+@Injectable()
+export class AppointmentSchedulerService {
+  private readonly logger = new Logger(AppointmentSchedulerService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Cron job que se ejecuta cada hora para revisar citas pendientes que ya han finalizado
+   * y marcarlas como "no_asistida"
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async processExpiredAppointments(): Promise<void> {
+    this.logger.log(
+      'Iniciando procesamiento de citas expiradas para marcar como no_asistida...',
+    );
+
+    try {
+      const expiredAppointments = await this.getExpiredPendingAppointments();
+      if (expiredAppointments.length === 0) {
+        this.logger.log('No se encontraron citas pendientes expiradas');
+        return;
+      }
+
+      this.logger.log(
+        `Encontradas ${expiredAppointments.length} citas pendientes expiradas`,
+      );
+
+      const updatedCount =
+        await this.markAppointmentsAsMissed(expiredAppointments);
+
+      this.logger.log(
+        `Procesamiento completado: ${updatedCount} citas marcadas como no_asistida`,
+      );
+    } catch (error) {
+      this.logger.error('Error procesando citas expiradas:', error);
+    }
+  }
+  /**
+   * Obtiene todas las citas con estado "pendiente" cuya fecha/hora de fin ya ha pasado
+   */
+  private async getExpiredPendingAppointments() {
+    const now = new Date();
+
+    return await this.prisma.appointment.findMany({
+      where: {
+        status: status_type.pendiente,
+        end: {
+          lt: now, // end time is less than current time
+        },
+        deleted: false,
+      },
+      select: {
+        id: true,
+        consultation_reason: true,
+        start: true,
+        end: true,
+        patient_id: true,
+        physician_id: true,
+        tenant_id: true,
+        patient: {
+          select: {
+            name: true,
+            last_name: true,
+            email: true,
+          },
+        },
+        physician: {
+          select: {
+            name: true,
+            last_name: true,
+          },
+        },
+      },
+    });
+  }
+  /**
+   * Actualiza las citas expiradas marcándolas como "no_asistida"
+   */
+  private async markAppointmentsAsMissed(
+    expiredAppointments: Array<{
+      id: string;
+      consultation_reason: string;
+      start: Date;
+      end: Date;
+      patient_id: string;
+      physician_id: string;
+      tenant_id: string;
+      patient: {
+        name: string;
+        last_name: string | null;
+        email: string;
+      };
+      physician: {
+        name: string;
+        last_name: string | null;
+      };
+    }>,
+  ): Promise<number> {
+    const appointmentIds = expiredAppointments.map((apt) => apt.id);
+
+    const result = await this.prisma.appointment.updateMany({
+      where: {
+        id: {
+          in: appointmentIds,
+        },
+        status: status_type.pendiente, // Double-check to ensure only pending appointments are updated
+      },
+      data: {
+        status: 'no_asistida' as status_type,
+        updated_at: new Date(),
+      },
+    });
+
+    // Log each appointment that was updated for audit purposes
+    for (const appointment of expiredAppointments) {
+      this.logger.debug(
+        `Cita marcada como no_asistida - ID: ${appointment.id}, ` +
+          `Paciente: ${appointment.patient?.name} ${appointment.patient?.last_name}, ` +
+          `Médico: ${appointment.physician?.name} ${appointment.physician?.last_name}, ` +
+          `Fecha fin: ${appointment.end}`,
+      );
+    }
+
+    return result.count;
+  }
+  /**
+   * Método manual para procesar citas expiradas (útil para testing o ejecución manual)
+   */
+  async manualProcessExpiredAppointments(): Promise<{
+    processedCount: number;
+    expiredAppointments: any[];
+  }> {
+    this.logger.log('Procesamiento manual de citas expiradas iniciado');
+
+    const expiredAppointments = await this.getExpiredPendingAppointments();
+    const processedCount =
+      expiredAppointments.length > 0
+        ? await this.markAppointmentsAsMissed(expiredAppointments)
+        : 0;
+
+    return {
+      processedCount,
+      expiredAppointments,
+    };
+  }
+
+  /**
+   * Obtiene estadísticas de citas por estado en un rango de fechas
+   */
+  async getAppointmentStatusStatistics(
+    startDate?: Date,
+    endDate?: Date,
+    tenantId?: string,
+  ): Promise<{
+    total: number;
+    pendiente: number;
+    atendida: number;
+    cancelada: number;
+    no_asistida: number;
+  }> {
+    const whereClause: any = {
+      deleted: false,
+    };
+
+    if (startDate && endDate) {
+      whereClause.start = {
+        gte: startDate,
+        lte: endDate,
+      };
+    }
+
+    if (tenantId) {
+      whereClause.tenant_id = tenantId;
+    }
+
+    const appointments = await this.prisma.appointment.groupBy({
+      by: ['status'],
+      where: whereClause,
+      _count: {
+        status: true,
+      },
+    });
+
+    const stats = {
+      total: 0,
+      pendiente: 0,
+      atendida: 0,
+      cancelada: 0,
+      no_asistida: 0,
+    };
+
+    appointments.forEach((group) => {
+      const count = group._count.status;
+      stats[group.status as keyof typeof stats] = count;
+      stats.total += count;
+    });
+
+    return stats;
+  }
+}


### PR DESCRIPTION
## Resumen
Implementación completa de un sistema scheduler que marca automáticamente las citas médicas pendientes como "no_asistida" cuando han pasado su hora de finalización.

## Funcionalidades implementadas

### 🔄 Scheduler Automático
- **Frecuencia**: Se ejecuta diariamente a medianoche
- **Función**: Revisa todas las citas con estado "pendiente" cuya fecha/hora de fin ya ha pasado
- **Acción**: Las marca automáticamente como "no_asistida"

### 🗄️ Base de Datos
- Agregado nuevo estado `no_asistida` al enum `status_type` en schema.prisma
- Actualizado CreateAppointmentDto para incluir validaciones del nuevo estado
- Migración de base de datos preparada

### 🎮 API REST (Funcionalidades adicionales)
- `POST /appointment-scheduler/process-expired` - Procesamiento manual para testing
- `GET /appointment-scheduler/statistics` - Estadísticas de citas por estado
- Documentación Swagger completa
- Protección con guards de seguridad existentes

### 📊 Logging y Auditoría
- Registro completo de todas las operaciones
- Logs detallados de cada cita procesada
- Manejo de errores con logging apropiado