### PR TITLE
fix: actualizar campo dni a identification_number en CreateUserDto

### DIFF
--- a/src/docs/auth.md
+++ b/src/docs/auth.md
@@ -18,7 +18,7 @@ Registra un nuevo usuario en el sistema.
   "last_name": "Pérez",
   "email": "juan.perez@example.com",
   "password": "StrongP@ss123",
-  "dni": "12345678",
+  "identification_number": "12345678",
   "phone_prefix": "+52",
   "phone": "9876543210",
   "role": "patient"

--- a/src/docs/user.md
+++ b/src/docs/user.md
@@ -181,7 +181,7 @@ Elimina un usuario del tenant actual.
   name?: string;
   last_name?: string;
   email?: string;
-  dni?: string;
+  identification_number?: string;
   dniType?: string;
   birthdate?: Date;
   nationality?: string;
@@ -209,7 +209,7 @@ Contiene las propiedades básicas para un usuario:
   name: string;               // Nombre del usuario
   last_name: string;          // Apellido del usuario
   email: string;              // Correo electrónico
-  dni?: string;               // Número de documento de identidad
+  identification_number?: string; // Número de documento de identidad
   birth_date?: Date;          // Fecha de nacimiento
   nationality?: string;       // Nacionalidad
   gender?: string;            // Género

--- a/src/management/patient/patient.service.ts
+++ b/src/management/patient/patient.service.ts
@@ -38,7 +38,7 @@ export class PatientService {
         throw new BadRequestException('No se ha especificado un tenant válido');
       }
 
-      const newPassword = `${user.name.charAt(0).toUpperCase() + user.name.slice(1) + '.' + user.dni}`;
+      const newPassword = `${user.name.charAt(0).toUpperCase() + user.name.slice(1) + '.' + user.identification_number}`;
 
       // Buscar si ya existe un usuario con ese email
       const existingUser = await this.prisma.user.findFirst({
@@ -349,7 +349,7 @@ export class PatientService {
             orderBy === 'name' ||
             orderBy === 'last_name' ||
             orderBy === 'email' ||
-            orderBy === 'dni'
+            orderBy === 'identification_number'
               ? { user: { [orderBy]: orderDirection } }
               : { [orderBy]: orderDirection },
         }),

--- a/src/management/user/dto/create-user.dto.ts
+++ b/src/management/user/dto/create-user.dto.ts
@@ -45,10 +45,14 @@ export class BaseUserDto {
     minLength: 7,
     maxLength: 9,
   })
-  @IsString({ message: 'El DNI debe ser un texto válido.' })
-  @Length(7, 9, { message: 'El DNI debe tener entre 7 y 9 caracteres.' })
+  @IsString({
+    message: 'El número de identificación debe ser un texto válido.',
+  })
+  @Length(7, 9, {
+    message: 'El número de identificación debe tener entre 7 y 9 caracteres.',
+  })
   @IsOptional()
-  dni?: string;
+  identification_number?: string;
 
   @ApiPropertyOptional({
     description: "User's birth date",

--- a/src/management/user/entities/user.interface.ts
+++ b/src/management/user/entities/user.interface.ts
@@ -6,7 +6,7 @@ export interface User {
   name?: string;
   last_name?: string;
   email?: string;
-  dni?: string;
+  identification_number?: string;
   dniType?: string;
   birthdate?: Date;
   nationality?: string;


### PR DESCRIPTION
Título: Corregir campo de identificación en DTO de usuario

## 🐛 Problema
El endpoint POST /auth/register estaba fallando con el error:
"Unknown argument dni. Did you mean id? Available options are marked with ?."

## 🔍 Causa
Inconsistencia entre el esquema de Prisma (que usa `identification_number`) y el DTO CreateUserDto (que usaba `dni`).

## ✅ Solución
- Actualizado BaseUserDto para usar `identification_number` en lugar de `dni`
- Corregidos mensajes de validación
- Actualizada documentación en auth.md y user.md
- Mantenida consistencia con el resto del código que ya usaba `identification_number`

## 🧪 Pruebas
- Verificado que el DTO coincide con el esquema de Prisma
- Comprobado que no hay errores de compilación
- Confirmado que la documentación está actualizada

## 📚 Archivos Modificados
- `src/management/user/dto/create-user.dto.ts`
- `src/docs/auth.md`
- `src/docs/user.md`

## 🔗 Relacionado
Resuelve el error de registro de usuarios pacientes desde